### PR TITLE
Add gitattributes to reduce unnecessary files from composer installs.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/docs/ export-ignore
+/test/ export-ignore
+/utils/ export-ignore
+/.buildpath export-ignore
+/.gitignore export-ignore
+/.project export-ignore
+/.travis.yml export-ignore


### PR DESCRIPTION
When using the composer argument `--prefer-dist`, git archives will be used. This reduces files that are typically useless when using phpCAS as a library, as opposed to developing it. When using phpCAS as a library, and deploying, tests and raw documentation are unnecassary. When developing phpCAS, the preferred method is a git clone, and will continue to work properly.