### PR TITLE
Fix non-strict string comparision in _isHttps check #139

### DIFF
--- a/source/CAS/Client.php
+++ b/source/CAS/Client.php
@@ -3528,7 +3528,7 @@ class CAS_Client
         }
         if ( isset($_SERVER['HTTPS'])
             && !empty($_SERVER['HTTPS'])
-            && $_SERVER['HTTPS'] != 'off'
+            && $_SERVER['HTTPS'] !== 'off'
         ) {
             return true;
         } else {


### PR DESCRIPTION
The ```_isHttps``` check was doing a non-strict string comparison which was causing it to fail intermittently. PHP  will sometimes convert strings to numbers when comparing them unless the check is strict.

I believe this will solve #139