### PR TITLE
_getClientUrl() fixes with reverse proxies

### DIFF
--- a/source/CAS/Client.php
+++ b/source/CAS/Client.php
@@ -3488,7 +3488,8 @@ class CAS_Client
         if (!empty($_SERVER['HTTP_X_FORWARDED_HOST'])) {
             // explode the host list separated by comma and use the first host
             $hosts = explode(',', $_SERVER['HTTP_X_FORWARDED_HOST']);
-            $server_url = $hosts[0];
+            // see rfc7239#5.3 and rfc7230#2.7.1: port is in HTTP_X_FORWARDED_HOST if non default
+            return $hosts[0];
         } else if (!empty($_SERVER['HTTP_X_FORWARDED_SERVER'])) {
             $server_url = $_SERVER['HTTP_X_FORWARDED_SERVER'];
         } else {


### PR DESCRIPTION
If HTTP_X_FORWARDED_HOST header does not contain a port, it's assumed to be the default one for the protocol.

See http://tools.ietf.org/html/rfc7239#section-5.3:

> The syntax for a "host" value, after potential quoted-string
   unescaping, MUST conform to the Host ABNF described in Section 5.4 of
   [RFC7230].

and http://tools.ietf.org/html/rfc7230#section-2.7.1:
> If the host identifier is provided as an IP address, the origin
   server is the listener (if any) on the indicated TCP port at that IP
   address.  If host is a registered name, the registered name is an
   indirect identifier for use with a name resolution service, such as
   DNS, to find an address for that origin server.  _If the port
   subcomponent is empty or not given, TCP port 80 (the reserved port
   for WWW services) is the default._

This does not mention HTTPS, but an older version of the rfc was clearer: http://tools.ietf.org/html/rfc2616#section-14.23
> A "host" without any trailing port information implies the default
   port for the service requested (e.g., "80" for an HTTP URL).