### PR TITLE
Added time to phpCAS trace

### DIFF
--- a/source/CAS.php
+++ b/source/CAS.php
@@ -445,7 +445,7 @@ class phpCAS
             self::$_PHPCAS_DEBUG['filename'] = $filename;
             self::$_PHPCAS_DEBUG['indent'] = 0;
 
-            phpCAS :: trace('START phpCAS-' . PHPCAS_VERSION . ' ******************');
+            phpCAS :: trace('START ('.date("Y-m-d H:i:s").') phpCAS-' . PHPCAS_VERSION . ' ******************');
         }
     }
 


### PR DESCRIPTION
Added a timestamp to the start of the phpCAS::trace() method for
debugging help.