### PR TITLE
Fixed translations for Greek and Japanese.

### DIFF
--- a/source/CAS/Languages/Greek.php
+++ b/source/CAS/Languages/Greek.php
@@ -49,7 +49,7 @@ class CAS_Languages_Greek implements CAS_Languages_LanguageInterface
      */
     public function getUsingServer()
     {
-        return '÷ñçóéìïðïéåßôáé ï åîõðçñåôçôÞò';
+        return 'χρησιμοποιείται ο εξυπηρετητής';
     }
 
     /**
@@ -59,7 +59,7 @@ class CAS_Languages_Greek implements CAS_Languages_LanguageInterface
      */
     public function getAuthenticationWanted()
     {
-        return 'Áðáéôåßôáé ç ôáõôïðïßçóç CAS!';
+        return 'Απαιτείται η ταυτοποίηση CAS!';
     }
 
     /**
@@ -69,7 +69,7 @@ class CAS_Languages_Greek implements CAS_Languages_LanguageInterface
      */
     public function getLogout()
     {
-        return 'Áðáéôåßôáé ç áðïóýíäåóç áðü CAS!';
+        return 'Απαιτείται η αποσύνδεση από CAS!';
     }
 
     /**
@@ -79,7 +79,7 @@ class CAS_Languages_Greek implements CAS_Languages_LanguageInterface
      */
     public function getShouldHaveBeenRedirected()
     {
-        return 'Èá Ýðñåðå íá åß÷áôå áíáêáôåõèõíèåß óôïí åîõðçñåôçôÞ CAS. ÊÜíôå êëßê <a href="%s">åäþ</a> ãéá íá óõíå÷ßóåôå.';
+        return 'Θα έπρεπε να είχατε ανακατευθυνθεί στον εξυπηρετητή CAS. Κάντε κλίκ <a href="%s">εδώ</a> για να συνεχίσετε.';
     }
 
     /**
@@ -89,7 +89,7 @@ class CAS_Languages_Greek implements CAS_Languages_LanguageInterface
      */
     public function getAuthenticationFailed()
     {
-        return 'Ç ôáõôïðïßçóç CAS áðÝôõ÷å!';
+        return 'Η ταυτοποίηση CAS απέτυχε!';
     }
 
     /**
@@ -99,7 +99,7 @@ class CAS_Languages_Greek implements CAS_Languages_LanguageInterface
      */
     public function getYouWereNotAuthenticated()
     {
-        return '<p>Äåí ôáõôïðïéçèÞêáôå.</p><p>Ìðïñåßôå íá îáíáðñïóðáèÞóåôå, êÜíïíôáò êëßê <a href="%s">åäþ</a>.</p><p>Åáí ôï ðñüâëçìá åðéìåßíåé, åëÜôå óå åðáöÞ ìå ôïí <a href="mailto:%s">äéá÷åéñéóôÞ</a>.</p>';
+        return '<p>Δεν ταυτοποιηθήκατε.</p><p>Μπορείτε να ξαναπροσπαθήσετε, κάνοντας κλίκ <a href="%s">εδώ</a>.</p><p>Εαν το πρόβλημα επιμείνει, ελάτε σε επαφή με τον <a href="mailto:%s">διαχειριστή</a>.</p>';
     }
 
     /**
@@ -109,7 +109,7 @@ class CAS_Languages_Greek implements CAS_Languages_LanguageInterface
      */
     public function getServiceUnavailable()
     {
-        return 'Ç õðçñåóßá `<b>%s</b>\' äåí åßíáé äéáèÝóéìç (<b>%s</b>).';
+        return 'Η υπηρεσία `<b>%s</b>\' δεν είναι διαθέσιμη (<b>%s</b>).';
     }
 }
 ?>

--- a/source/CAS/Languages/Japanese.php
+++ b/source/CAS/Languages/Japanese.php
@@ -28,7 +28,7 @@
  */
 
 /**
- * Japanese language class. Now Encoding is EUC-JP and LF
+ * Japanese language class. Now Encoding is UTF-8.
  *
  * @class    CAS_Languages_Japanese
  * @category Authentication
@@ -47,7 +47,7 @@ class CAS_Languages_Japanese implements CAS_Languages_LanguageInterface
      */
     public function getUsingServer()
     {
-        return 'using server';
+        return 'サーバーを使っています。';
     }
 
     /**
@@ -57,7 +57,7 @@ class CAS_Languages_Japanese implements CAS_Languages_LanguageInterface
      */
     public function getAuthenticationWanted()
     {
-        return 'CAS�ˤ��ǧ�ڤ�Ԥ��ޤ�';
+        return 'CASによる認証を行います。';
     }
 
     /**
@@ -67,7 +67,7 @@ class CAS_Languages_Japanese implements CAS_Languages_LanguageInterface
      */
     public function getLogout()
     {
-        return 'CAS����?�����Ȥ��ޤ�!';
+        return 'CASからログアウトします!';
     }
 
     /**
@@ -77,7 +77,7 @@ class CAS_Languages_Japanese implements CAS_Languages_LanguageInterface
      */
     public function getShouldHaveBeenRedirected()
     {
-        return 'CAS�����Ф˹Ԥ�ɬ�פ�����ޤ�����ưŪ��ž������ʤ����� <a href="%s">������</a> �򥯥�å�����³�Ԥ��ޤ��';
+        return 'CASサーバに行く必要があります。自動的に転送されない場合は <a href="%s">こちら</a> をクリックして続行します。';
     }
 
     /**
@@ -87,7 +87,7 @@ class CAS_Languages_Japanese implements CAS_Languages_LanguageInterface
      */
     public function getAuthenticationFailed()
     {
-        return 'CAS�ˤ��ǧ�ڤ˼��Ԥ��ޤ���';
+        return 'CASによる認証に失敗しました。';
     }
 
     /**
@@ -97,7 +97,7 @@ class CAS_Languages_Japanese implements CAS_Languages_LanguageInterface
      */
     public function getYouWereNotAuthenticated()
     {
-        return '<p>ǧ�ڤǤ��ޤ���Ǥ���.</p><p>�⤦���٥ꥯ�����Ȥ������������<a href="%s">������</a>�򥯥�å�.</p><p>���꤬��褷�ʤ����� <a href="mailto:%s">���Υ����Ȥδ����</a>���䤤��碌�Ƥ�������.</p>';
+        return '<p>認証できませんでした。</p><p>もう一度リクエストを送信する場合は<a href="%s">こちら</a>をクリック。</p><p>問題が解決しない場合は <a href="mailto:%s">このサイトの管理者</a>に問い合わせてください。</p>';
     }
 
     /**
@@ -107,7 +107,7 @@ class CAS_Languages_Japanese implements CAS_Languages_LanguageInterface
      */
     public function getServiceUnavailable()
     {
-        return '�����ӥ� `<b>%s</b>\' �����ѤǤ��ޤ��� (<b>%s</b>).';
+        return 'サービス `<b>%s</b>\' は利用できません (<b>%s</b>)。';
     }
 }
 ?>


### PR DESCRIPTION
The Greek and Japanese translations seem to have broken since before even the move to Git. I've checked out the last revision of the translations and fixed the file encodings.

I've also fixed up the punctuation a little on the Japanese translation and added a missing translation.