### PR TITLE
Ignore Composer-related files and directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ utils/dist/
 utils/tmp/
 utils/starting_HEAD
 /.settings
+
+# Composer
+composer.lock
+/vendor/


### PR DESCRIPTION
The vendors directory should never be under version control, and for
libraries, the lock file should not either.