### PR TITLE
#203 - Fix errors in source/CAS.php when run under phpdbg

### DIFF
--- a/source/CAS.php
+++ b/source/CAS.php
@@ -40,10 +40,8 @@
 // hack by Vangelis Haniotakis to handle the absence of $_SERVER['REQUEST_URI']
 // in IIS
 //
-if (php_sapi_name() != 'cli') {
-    if (!isset($_SERVER['REQUEST_URI'])) {
-        $_SERVER['REQUEST_URI'] = $_SERVER['SCRIPT_NAME'] . '?' . $_SERVER['QUERY_STRING'];
-    }
+if (!isset($_SERVER['REQUEST_URI']) && isset($_SERVER['SCRIPT_NAME']) && isset($_SERVER['QUERY_STRING'])) {
+    $_SERVER['REQUEST_URI'] = $_SERVER['SCRIPT_NAME'] . '?' . $_SERVER['QUERY_STRING'];
 }
 
 // Add a E_USER_DEPRECATED for php versions <= 5.2


### PR DESCRIPTION
This code assumed any SAPI other than "cli" is a web request, which is not the
case for phpdbg, the debugger that ships with PHP 5.6. Since phpdbg is
implemented as a SAPI module, the php_sapi_name() function will return "phpdbg".
If you haven't set up the $_SERVER superglobal beforehand, this code would
trigger "Undefined index" errors when run under phpdbg.

I opted to fix this by removing the php_sapi_name() check, as it's not
necessary. Just checking the superglobals with isset() is sufficient.