### PR TITLE
Added setCasAttributeParser call back

### DIFF
--- a/source/CAS.php
+++ b/source/CAS.php
@@ -995,6 +995,25 @@ class phpCAS
         }
     }
 
+
+    /**
+     * Set a callback function to be run when receiving CAS attributes
+     *
+     * The callback function will be passed an $success_elements
+     * payload of the response (\DOMElement) as its first parameter.
+     *
+     * @param string $function       Callback function
+     * @param array  $additionalArgs optional array of arguments
+     *
+     * @return void
+     */
+    public static function setCasAttributeParserCallback($function, array $additionalArgs = array())
+    {
+        phpCAS::_validateClientExists();
+
+        self::$_PHPCAS_CLIENT->setCasAttributeParserCallback($function, $additionalArgs);
+    }
+
     /**
      * Set a callback function to be run when a user authenticates.
      *


### PR DESCRIPTION
Hello, I'd like to propose a new callback for the parsing of CAS attributes.

Some environment send custom attributes responses which fail to be parsed correctly by phpCAS

For instance, attributes like this : 
```
<cas:authenticationSuccess>
    <cas:user>gboddin</cas:user>
    <cas:groups number="2">
        <cas:group>GROUP1</cas:group>
        <cas:group>GROUP1</cas:group>
    </cas:groups>
    <cas:ticketType>SERVICE</cas:ticketType>
        <!-- and so on ... -->
</cas:authenticationSuccess>
```
are returning this result with `phpCAS::getAttributes` : 
```
array (size=21)
  'user' => string 'gboddin' (length=7)
  'groups' => string 'GROUP1GROUP2GROUP3GROUP4GROUP5' (length=28)
  'ticketType' => string 'SERVICE' (length=7)
```

The callback can the be implemented pretty much like the postAuthCallback : 
```php
//config the client as usual
phpCAS::client(
    constant($config['cas.version']),
    $config['cas.host'],
    (int) $config['cas.port'],
    $config['cas.uri'],
    false
);

phpCAS::setCasAttributeParserCallback(
  function(\DOMElement $succes_elements) {
    //parse the content of authSuccess XML here
    //and return an array()
  } 
);
//set the attribute callback via object
phpCAS::setCasAttributeParserCallback(
    array(
      new \EcasPhpCASParser\EcasPhpCASParser,
      'parse'
    )
);
```
Thanks for the software btw !