### PR TITLE
Add a setter for the cas client

### DIFF
--- a/source/CAS.php
+++ b/source/CAS.php
@@ -1801,6 +1801,16 @@ class phpCAS
             throw new CAS_OutOfSequenceBeforeProxyException();
         }
     }
+
+    /**
+     * For testing purposes, use this method to set the client to a test double
+     *
+     * @return void
+     */
+    public static function setCasClient(\CAS_Client $client)
+    {
+        self::$_PHPCAS_CLIENT = $client;
+    }
 }
 // ########################################################################
 // DOCUMENTATION


### PR DESCRIPTION
Currently, it is very hard to unit test a class that uses phpCAS with
the recommended way, because you cannot replace the cas client with a
mock that would allow to record how it is called.