### PR TITLE
Added check for HTTP_X_FORWARDED_PROTOCOL header in _isHttps

### DIFF
--- a/source/CAS/Client.php
+++ b/source/CAS/Client.php
@@ -3618,15 +3618,16 @@ class CAS_Client
     {
         if (!empty($_SERVER['HTTP_X_FORWARDED_PROTO'])) {
             return ($_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https');
-        }
-        if ( isset($_SERVER['HTTPS'])
+        } elseif (!empty($_SERVER['HTTP_X_FORWARDED_PROTOCOL'])) {
+            return ($_SERVER['HTTP_X_FORWARDED_PROTOCOL'] === 'https');
+        } elseif ( isset($_SERVER['HTTPS'])
             && !empty($_SERVER['HTTPS'])
             && strcasecmp($_SERVER['HTTPS'], 'off') !== 0
         ) {
             return true;
-        } else {
-            return false;
         }
+        return false;
+
     }
 
     /**


### PR DESCRIPTION
Fixes Jasig/phpCAS#219 in those rare cases where reverse proxies send non-RFC headers