### PR TITLE
Fixes Logout replication issue (Jasig/phpCAS#213)

### DIFF
--- a/source/CAS/Request/CurlMultiRequest.php
+++ b/source/CAS/Request/CurlMultiRequest.php
@@ -122,7 +122,7 @@ implements CAS_Request_MultiRequestInterface
         $handles = array();
         $multiHandle = curl_multi_init();
         foreach ($this->_requests as $i => $request) {
-            $handle = $request->_initAndConfigure();
+            $handle = $request->initAndConfigure();
             curl_setopt($handle, CURLOPT_RETURNTRANSFER, true);
             $handles[$i] = $handle;
             curl_multi_add_handle($multiHandle, $handle);

--- a/source/CAS/Request/CurlRequest.php
+++ b/source/CAS/Request/CurlRequest.php
@@ -67,7 +67,7 @@ implements CAS_Request_RequestInterface
         /*********************************************************
          * initialize the CURL session
         *********************************************************/
-        $ch = $this->_initAndConfigure();
+        $ch = $this->initAndConfigure();
 
         /*********************************************************
          * Perform the query
@@ -99,7 +99,7 @@ implements CAS_Request_RequestInterface
      *
      * @return resource The cURL handle on success, false on failure
      */
-    private function _initAndConfigure()
+    public function initAndConfigure()
     {
         /*********************************************************
          * initialize the CURL session


### PR DESCRIPTION
I simply made the method public ( and removed the _ ).

CurlMultiRequest and CurlRequest seems to be the only 2 places where this is used.